### PR TITLE
Request screen implemented

### DIFF
--- a/frontend/lendme/lib/components/avatar.dart
+++ b/frontend/lendme/lib/components/avatar.dart
@@ -1,7 +1,6 @@
-import 'dart:io';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:lendme/components/circle_image.dart';
 
 // Widget that shows user avatar in circle with border
 // Url param may be network address (prefixed with http) or path to file in local storage
@@ -13,77 +12,10 @@ class Avatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Container(
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-              border: Border.all(
-                color: Theme.of(context).primaryColor,
-                width: 2,
-              ),
-          ),
-          child: ClipOval(
-            child: SizedBox(
-              width: size,
-              height: size,
-              child: properImage(),
-            ),
-          ),
-        ),
-      ],
+    return CircleImage(
+        url: url,
+        defaultImage: "assets/images/user_default.png",
+        size: size
     );
-  }
-
-  Widget properImage() {
-    final fUrl = url;
-    if(fUrl == null) {
-      return placeholderImage();
-    } else if(fUrl.startsWith("http")) {
-      return networkImage(fUrl);
-    } else {
-      return fileImage(fUrl);
-    }
-  }
-
-  Widget fileImage(String url) {
-    return Container(
-      decoration: BoxDecoration(
-        image: DecorationImage(
-          image: FileImage(File(url)),
-          fit: BoxFit.contain,
-        ),
-      ),
-    );
-  }
-
-  Widget networkImage(String url) {
-    return CachedNetworkImage(
-        imageUrl: url,
-        width: 60,
-        height: 60,
-        fit: BoxFit.fitHeight,
-        placeholder: (context, url) {
-          return Stack(
-            children: [
-              placeholderImage(),
-              const Positioned(
-                left: 10,
-                right: 10,
-                top: 10,
-                bottom: 10,
-                child: CircularProgressIndicator(),
-              ),
-            ],
-          );
-        },
-        errorWidget: (context, url, error) =>
-        const Icon(Icons.error, size: 45)
-    );
-  }
-
-  Widget placeholderImage() {
-    return Image.asset("assets/images/user_default.png");
   }
 }

--- a/frontend/lendme/lib/components/circle_image.dart
+++ b/frontend/lendme/lib/components/circle_image.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+class CircleImage extends StatelessWidget {
+  const CircleImage({required this.url, required this.defaultImage, this.size=50.0, Key? key}) : super(key: key);
+
+  final String? url;
+  final double size;
+  final String defaultImage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: Theme.of(context).primaryColor,
+              width: 2,
+            ),
+          ),
+          child: ClipOval(
+            child: SizedBox(
+              width: size,
+              height: size,
+              child: properImage(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget properImage() {
+    final fUrl = url;
+    if(fUrl == null) {
+      return placeholderImage();
+    } else if(fUrl.startsWith("http")) {
+      return networkImage(fUrl);
+    } else {
+      return fileImage(fUrl);
+    }
+  }
+
+  Widget fileImage(String url) {
+    return Container(
+      decoration: BoxDecoration(
+        image: DecorationImage(
+          image: FileImage(File(url)),
+          fit: BoxFit.contain,
+        ),
+      ),
+    );
+  }
+
+  Widget networkImage(String url) {
+    return CachedNetworkImage(
+        imageUrl: url,
+        width: 60,
+        height: 60,
+        fit: BoxFit.cover,
+        placeholder: (context, url) {
+          return Stack(
+            children: [
+              placeholderImage(),
+              const Positioned(
+                left: 10,
+                right: 10,
+                top: 10,
+                bottom: 10,
+                child: CircularProgressIndicator(),
+              ),
+            ],
+          );
+        },
+        errorWidget: (context, url, error) =>
+        const Icon(Icons.error, size: 45)
+    );
+  }
+
+  Widget placeholderImage() {
+    return Image.asset(
+      defaultImage,
+      fit: BoxFit.cover,
+    );
+  }
+}

--- a/frontend/lendme/lib/components/item_circle_image.dart
+++ b/frontend/lendme/lib/components/item_circle_image.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import 'circle_image.dart';
+
+class ItemCricleImage extends StatelessWidget {
+  const ItemCricleImage({required this.url, this.size=50.0, Key? key}) : super(key: key);
+
+  final String? url;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return CircleImage(
+        url: url,
+        defaultImage: "assets/images/item_default.jpg",
+        size: size
+    );
+  }
+}

--- a/frontend/lendme/lib/components/item_view.dart
+++ b/frontend/lendme/lib/components/item_view.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:lendme/components/avatar.dart';
+import 'package:lendme/components/item_circle_image.dart';
+import 'package:lendme/models/item.dart';
+import 'package:lendme/models/user.dart';
+import 'package:lendme/repositories/item_repository.dart';
+import 'package:lendme/repositories/user_repository.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+
+class ItemView extends StatelessWidget {
+  ItemView({required this.itemId, Key? key})
+      : super(key: key);
+
+  final String itemId;
+  final ItemRepository _itemsRepository = ItemRepository();
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder(
+      stream: _itemsRepository.getItemStream(itemId),
+      builder: _buildFromUser,
+    );
+  }
+
+  Widget _buildFromUser(BuildContext context, AsyncSnapshot<Item?> itemSnap) {
+    final item = itemSnap.data;
+
+    return Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.transparent,
+        border: Border.all(color: Colors.white),
+        borderRadius: const BorderRadius.all(
+          Radius.circular(10),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.max,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              ItemCricleImage(url: item?.imageUrl, size: 60.0),
+              Expanded(child: _rightColumn(context, item))
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _rightColumn(BuildContext context, Item? item) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        const SizedBox(height: 8),
+        Text(
+            item?.title ?? '',
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              color: Colors.black,
+            )
+        ),
+        const SizedBox(height: 2),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Text(
+              'Description: ' + (item?.description ?? 'No description'),
+              style: const TextStyle(
+                fontSize: 13,
+                color: Colors.black,
+              ),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        _button(context, item),
+      ],
+    );
+  }
+
+  Row _button(BuildContext context, Item? item) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextButton.icon(
+          label: const Text('Show this item'),
+          icon: const Icon(Icons.category_rounded),
+          style: TextButton.styleFrom(
+            primary: Colors.white,
+          ),
+          onPressed: () {
+            Navigator.of(context).pushNamed('/item_details', arguments: itemId);
+          },
+        ),
+      ],
+    );
+  }
+
+}

--- a/frontend/lendme/lib/components/user_view.dart
+++ b/frontend/lendme/lib/components/user_view.dart
@@ -40,8 +40,7 @@ class UserView extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Avatar(url: user?.avatarUrl, size: 60.0),
-              const SizedBox(width: 16),
-              _rightColumn(user)
+              Expanded(child: _rightColumn(user))
             ],
           ),
         ],
@@ -53,6 +52,7 @@ class UserView extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
+        const SizedBox(height: 8),
         Text(
           '${user?.info.firstName ?? ''} ${user?.info.lastName ?? ''}',
           style: const TextStyle(
@@ -69,6 +69,7 @@ class UserView extends StatelessWidget {
   Row _contactButtons(User? user) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
       children: [
         TextButton.icon(
           label: const Text('Call'),

--- a/frontend/lendme/lib/models/request.dart
+++ b/frontend/lendme/lib/models/request.dart
@@ -1,0 +1,57 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:lendme/models/request_status.dart';
+import 'package:lendme/models/request_type.dart';
+
+class Request {
+
+  String? id;
+  Timestamp endDate;
+  String issuerId;
+  String itemId;
+  String? requestMessage;
+  String? responseMessage;
+  RequestStatus status;
+  RequestType type;
+
+  Request({
+    this.id,
+    required this.endDate,
+    required this.issuerId,
+    required this.itemId,
+    this.requestMessage,
+    this.responseMessage,
+    required this.status,
+    required this.type
+  });
+
+
+  static Request? fromMap(Map<String, dynamic>? json, String? id) {
+    if(json == null) {
+      return null;
+    }
+    return Request(
+        id: id,
+        endDate: json['endDate'] as Timestamp,
+        issuerId: json['issuerId'] as String,
+        itemId: json['itemId'] as String,
+        requestMessage: json['requestMessage'] as String?,
+        responseMessage: json['responseMessage'] as String?,
+        status: RequestStatus.fromString(json['status']),
+        type: RequestType.fromString(json['type']),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'endDate': endDate,
+      'issuerId': issuerId,
+      'itemId': itemId,
+      'requestMessage': requestMessage,
+      'responseMessage': responseMessage,
+      'status': status.toString(),
+      'type': type.toString(),
+    };
+  }
+
+}

--- a/frontend/lendme/lib/models/request_status.dart
+++ b/frontend/lendme/lib/models/request_status.dart
@@ -1,0 +1,28 @@
+class RequestStatus {
+  final String _name;
+
+  const RequestStatus._(this._name);
+
+  static const RequestStatus pending = RequestStatus._('pending');
+  static const RequestStatus accepted = RequestStatus._('accepted');
+  static const RequestStatus rejected = RequestStatus._('rejected');
+
+  @override
+  String toString() {
+    return _name;
+  }
+
+  static RequestStatus fromString(String str) {
+    if(str == "pending") {
+      return RequestStatus.pending;
+    } else if(str == "accepted") {
+      return RequestStatus.accepted;
+    } else if(str == "rejected") {
+      return RequestStatus.rejected;
+    } else {
+      throw Exception("Invalid request type");
+    }
+  }
+
+}
+

--- a/frontend/lendme/lib/models/request_type.dart
+++ b/frontend/lendme/lib/models/request_type.dart
@@ -1,0 +1,28 @@
+class RequestType {
+  final String _name;
+
+  const RequestType._(this._name);
+
+  static const RequestType borrow = RequestType._('borrow');
+  static const RequestType extend = RequestType._('extend');
+  static const RequestType transfer = RequestType._('transfer');
+
+  @override
+  String toString() {
+    return _name;
+  }
+
+  static RequestType fromString(String str) {
+    if(str == "borrow") {
+      return RequestType.borrow;
+    } else if(str == "extend") {
+      return RequestType.extend;
+    } else if(str == "transfer") {
+      return RequestType.transfer;
+    } else {
+      throw Exception("Invalid request type");
+    }
+  }
+
+}
+

--- a/frontend/lendme/lib/repositories/request_repository.dart
+++ b/frontend/lendme/lib/repositories/request_repository.dart
@@ -1,0 +1,20 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:lendme/models/request.dart';
+
+class RequestRepository {
+
+  final FirebaseFirestore firestore = FirebaseFirestore.instance;
+
+  Stream<Request?> getRequestStream(String requestId) {
+    return firestore
+        .collection('requests')
+        .doc(requestId)
+        .snapshots()
+        .map((snapshot) {
+          print("Snapshot: ${snapshot.data()}");
+          final r = Request.fromMap(snapshot.data(), snapshot.id);
+          return r;
+      });
+  }
+
+}

--- a/frontend/lendme/lib/routes/main_routes.dart
+++ b/frontend/lendme/lib/routes/main_routes.dart
@@ -5,6 +5,7 @@ import 'package:lendme/screens/other/add_item.dart';
 import 'package:lendme/screens/other/history.dart';
 import 'package:lendme/screens/other/item_details/item_details.dart';
 import 'package:lendme/screens/other/lent_qr.dart';
+import 'package:lendme/screens/requests/request_screen.dart';
 import 'package:lendme/screens/settings/change_theme.dart';
 import 'package:lendme/screens/settings/credits.dart';
 import 'package:lendme/screens/settings/edit_profile.dart';
@@ -41,5 +42,9 @@ Route? mainRoutes(RouteSettings settings) {
   else if(settings.name == '/lent_qr') {
     var item = settings.arguments! as Item;
     return PageTransition(child: LentQr(item: item), type: PageTransitionType.fade);
+  }
+  else if(settings.name == '/request') {
+    var requestId = settings.arguments! as String;
+    return MaterialPageRoute(builder: (context) {return RequestScreen(requestId: requestId);});
   }
 }

--- a/frontend/lendme/lib/screens/home/notifications.dart
+++ b/frontend/lendme/lib/screens/home/notifications.dart
@@ -10,16 +10,32 @@ class Notifications extends StatefulWidget {
 class _NotificationsState extends State<Notifications> {
   @override
   Widget build(BuildContext context) {
-    return Stack(
-        children: const [
-          Placeholder(),
-          Center(child:
-          Text(
-              "Notifications",
-              style: TextStyle(fontSize: 40, color: Colors.grey, backgroundColor: Colors.white)
-          )
-          )
-        ]
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text("Sample requests:"),
+          const SizedBox(height: 16,),
+          ElevatedButton(
+              onPressed: () => showNotification("borrow"),
+              child: const Text('Borrow request')
+          ),
+          ElevatedButton(
+              onPressed: () => showNotification("transfer"),
+              child: const Text('Transfer request')
+          ),
+          ElevatedButton(
+              onPressed: () => showNotification("extend"),
+              child: const Text('Extend request')
+          ),
+        ],
+      ),
     );
   }
+
+  void showNotification(String id) {
+    Navigator.of(context).pushNamed('/request', arguments: id);
+  }
+
 }

--- a/frontend/lendme/lib/screens/requests/accept_reject_panel.dart
+++ b/frontend/lendme/lib/screens/requests/accept_reject_panel.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:lendme/exceptions/exceptions.dart';
+import 'package:lendme/models/request.dart';
+import 'package:lendme/models/user.dart';
+import 'package:lendme/screens/requests/handlers.dart';
+
+class AcceptRejectPanel extends StatefulWidget {
+  AcceptRejectPanel({required this.request, required this.user, Key? key}):
+        super(key: key);
+
+  final Request request;
+  final User user;
+
+  final RequestHandlers handlers = RequestHandlers();
+
+  @override
+  _AcceptRejectPanelState createState() => _AcceptRejectPanelState();
+}
+
+class _AcceptRejectPanelState extends State<AcceptRejectPanel> {
+
+  bool _pendingOperation = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return _pendingOperation ? _spinner() : _buttons();
+  }
+
+  Widget _buttons() {
+    return Row(
+      children: [
+        Expanded(
+          child: SizedBox(
+            height: 60,
+            child: ElevatedButton.icon(
+              icon: const Icon(Icons.thumb_up_rounded),
+              label: const Text('Accept'),
+              style: ElevatedButton.styleFrom(
+                  primary: Colors.green
+              ),
+              onPressed: () async => _performAccept(),
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: SizedBox(
+            height: 60,
+            child: ElevatedButton.icon(
+              icon: const Icon(Icons.thumb_down_rounded),
+              label: const Text('Reject'),
+              style: ElevatedButton.styleFrom(
+                  primary: Colors.red
+              ),
+              onPressed: () async => _performReject(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _spinner() {
+    return Row(
+      mainAxisSize: MainAxisSize.max,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: const [
+        SizedBox(
+          height: 60,
+          width: 60,
+          child: CircularProgressIndicator(),
+        ),
+      ],
+    );
+  }
+
+  Future _performAccept() async {
+    try {
+      setPending(true);
+      await widget.handlers.accept(widget.request, widget.user);
+      Navigator.of(context).pop();
+    } catch (e) {
+      // Do nothing, no time to implement
+    } finally {
+      setPending(false);
+    }
+  }
+
+  Future _performReject() async {
+    try {
+      setPending(true);
+      await widget.handlers.reject(widget.request, widget.user);
+      Navigator.of(context).pop();
+    } catch (e) {
+      // Do nothing, no time to implement
+    } finally {
+      setPending(false);
+    }
+  }
+
+  void setPending(bool pending) {
+    setState(() {
+      _pendingOperation = pending;
+    });
+  }
+
+}

--- a/frontend/lendme/lib/screens/requests/decision_panel.dart
+++ b/frontend/lendme/lib/screens/requests/decision_panel.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:lendme/models/item.dart';
+import 'package:lendme/models/request.dart';
+import 'package:lendme/models/request_status.dart';
+import 'package:lendme/models/user.dart';
+import 'package:lendme/screens/requests/accept_reject_panel.dart';
+
+class RequestDecisionPanel extends StatelessWidget {
+  const RequestDecisionPanel({required this.request, required this.user,
+    required this.item, Key? key}) : super(key: key);
+
+  final Request request;
+  final User user;
+  final Item item;
+
+  @override
+  Widget build(BuildContext context) {
+    return _showProperView();
+  }
+
+  Widget _showProperView() {
+    if(request.status == RequestStatus.pending) {
+      final isDecisivePerson = user.uid == item.ownerId;
+      return isDecisivePerson ? _pendingDecisiveState() : _pendingView();
+    } else if (request.status == RequestStatus.accepted) {
+      return _acceptedView();
+    } else {
+      return _rejectedView();
+    }
+  }
+
+  Widget _pendingView() {
+    return _genericView(
+        text: "Pending",
+        backgroundColor: Colors.grey,
+        textColor: Colors.black,
+        message: null,
+    );
+  }
+
+  Widget _acceptedView() {
+    return _genericView(
+        text: "Accepted",
+        backgroundColor: Colors.green,
+        textColor: Colors.black,
+        message: request.responseMessage,
+    );
+  }
+
+  Widget _rejectedView() {
+    return _genericView(
+        text: "Rejected",
+        backgroundColor: Colors.red,
+        textColor: Colors.black,
+        message: request.responseMessage,
+    );
+  }
+
+  Widget _genericView({required String text, required Color backgroundColor,
+    required Color textColor, String? message}) {
+    return Container(
+      decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: const BorderRadius.all(Radius.circular(10))),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                text,
+                style: TextStyle(
+                  color: textColor,
+                  fontSize: 17,
+                  fontWeight: FontWeight.bold,
+                )
+              ),
+            ],
+          ),
+          if(message != null)
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 8),
+                const Text(
+                  "Justification message:",
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                Text(message),
+              ],
+            )
+        ],
+      ),
+    );
+  }
+
+  Widget _responseMessage() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          "Justification message:",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Text(request.responseMessage ?? ''),
+      ],
+    );
+  }
+
+  Widget _pendingDecisiveState() {
+    return AcceptRejectPanel(
+      request: request,
+      user: user,
+    );
+  }
+
+}

--- a/frontend/lendme/lib/screens/requests/decision_panel.dart
+++ b/frontend/lendme/lib/screens/requests/decision_panel.dart
@@ -79,7 +79,7 @@ class RequestDecisionPanel extends StatelessWidget {
               ),
             ],
           ),
-          if(message != null)
+          if(message != null && message.isNotEmpty)
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [

--- a/frontend/lendme/lib/screens/requests/handlers.dart
+++ b/frontend/lendme/lib/screens/requests/handlers.dart
@@ -1,0 +1,43 @@
+import 'package:lendme/models/request.dart';
+import 'package:lendme/models/request_type.dart';
+import 'package:lendme/models/user.dart';
+
+class RequestHandlers {
+
+  Future accept(Request request, User user) async {
+    final type = request.type;
+    if(type == RequestType.borrow) {
+      await _acceptBorrow(request, user);
+    } else if(type == RequestType.extend) {
+      await _acceptExtend(request, user);
+    } else if(type == RequestType.transfer) {
+      await _acceptTransfer(request, user);
+    }
+  }
+
+  Future reject(Request request, User user) async {
+    // TODO: implement reject
+    await _stubOperation("Reject");
+  }
+
+  Future _acceptBorrow(Request request, User user) async {
+    // TODO: perform borrowing
+    await _stubOperation("Accept borrow");
+  }
+
+  Future _acceptExtend(Request request, User user) async {
+    // TODO: perform extending
+    await _stubOperation("Accept extend");
+  }
+
+  Future _acceptTransfer(Request request, User user) async {
+    // TODO: perform transferring
+    await _stubOperation("Accept transfer");
+  }
+
+  Future _stubOperation(String operationName) async {
+    print('Performing operation: $operationName');
+    await Future.delayed(const Duration(seconds: 2));
+  }
+
+}

--- a/frontend/lendme/lib/screens/requests/request_panel.dart
+++ b/frontend/lendme/lib/screens/requests/request_panel.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:lendme/components/user_view.dart';
+import 'package:lendme/models/item.dart';
+import 'package:lendme/models/rental.dart';
+import 'package:lendme/models/request.dart';
+import 'package:lendme/models/request_type.dart';
+import 'package:lendme/models/user.dart';
+import 'package:lendme/repositories/rental_repository.dart';
+import 'package:lendme/utils/constants.dart';
+
+class RequestPanel extends StatelessWidget {
+  const RequestPanel({required this.request, required this.user,
+    required this.item, Key? key}) : super(key: key);
+
+  final Request request;
+  final User user;
+  final Item? item;
+
+  @override
+  Widget build(BuildContext context) {
+    return _mainLayout();
+  }
+
+  Widget _mainLayout() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _title(),
+        if(request.type == RequestType.transfer)
+          _fromUser(),
+        if(request.type == RequestType.extend && item != null)
+          _FromTime(itemId: item!.id!),
+        _toTime(),
+        if(request.requestMessage != null && request.requestMessage!.isNotEmpty)
+          _message()
+      ],
+    );
+  }
+
+  Widget _title() {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Text(
+              _titleContent(),
+              style: const TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 17,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+
+  String _titleContent() {
+    if(request.type == RequestType.borrow) {
+      return 'Borrow item';
+    } else if(request.type == RequestType.extend) {
+      return 'Extend borrowing time';
+    } else if(request.type == RequestType.transfer) {
+      return 'Transfer item to me';
+    } else {
+      return '';
+    }
+  }
+
+  Widget _toTime() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          "To time:",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Text(dateTimeFormat.format(request.endDate.toDate())),
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+
+  Widget _fromUser() {
+    final ownerId = item?.ownerId;
+    if(ownerId == null) {
+      return Container();
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          "From user:",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 4),
+        UserView(userId: ownerId),
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+
+  Widget _message() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          "Justification message:",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Text(request.requestMessage ?? ''),
+      ],
+    );
+  }
+
+}
+
+
+class _FromTime extends StatelessWidget {
+  _FromTime({required this.itemId, Key? key}) : super(key: key);
+
+  final String itemId;
+  final RentalRepository _rentalRepository = RentalRepository();
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder(
+      stream: _rentalRepository.getItemActiveRentalStream(itemId),
+      builder: (BuildContext context, AsyncSnapshot<Rental?> rentalSnap) {
+        final rental = rentalSnap.data;
+        if(rental == null) {
+          return Container();
+        }
+        return _buildWithRental(context, rental);
+      },
+    );
+  }
+
+  Widget _buildWithRental(BuildContext context, Rental rental) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          "From time:",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Text(dateTimeFormat.format(rental.endDate.toDate())),
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+}

--- a/frontend/lendme/lib/screens/requests/request_screen.dart
+++ b/frontend/lendme/lib/screens/requests/request_screen.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:lendme/components/item_view.dart';
+import 'package:lendme/components/user_view.dart';
+import 'package:lendme/models/item.dart';
+import 'package:lendme/models/request.dart';
+import 'package:lendme/models/request_type.dart';
+import 'package:lendme/models/user.dart';
+import 'package:lendme/repositories/item_repository.dart';
+import 'package:lendme/repositories/request_repository.dart';
+import 'package:lendme/screens/requests/decision_panel.dart';
+import 'package:lendme/screens/requests/request_panel.dart';
+import 'package:provider/provider.dart';
+
+class RequestScreen extends StatelessWidget {
+  RequestScreen({required this.requestId, Key? key}) : super(key: key);
+
+  final String requestId;
+  final RequestRepository _requestRepository = RequestRepository();
+  final ItemRepository _itemRepository = ItemRepository();
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder(
+      stream: _requestRepository.getRequestStream(requestId),
+      builder: (BuildContext context, AsyncSnapshot<Request?> requestSnap) {
+        final request = requestSnap.data;
+        final user = Provider.of<User?>(context);
+        if(request == null || user == null) {
+          return Container();
+        }
+        else {
+          return StreamBuilder(
+            stream: _itemRepository.getItemStream(request.itemId),
+            builder: (BuildContext context, AsyncSnapshot<Item?> itemSnap) {
+              final item = itemSnap.data;
+              return buildFromData(context, request, user, item);
+            },
+          );
+        }
+      },
+    );
+  }
+
+  Widget buildFromData(BuildContext context, Request request, User user, Item? item) {
+    return Scaffold(
+      appBar: AppBar(
+          title: Text(_titleText(request)),
+          elevation: 0.0
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(12.0),
+          child: _mainLayout(context, request, user, item),
+        ),
+      ),
+    );
+  }
+
+  Column _mainLayout(BuildContext context, Request request, User user, Item? item) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _userPanel(context, request),
+        _itemPanel(context, request),
+        _requestPanel(context, request, user, item),
+        if(item != null)
+          _decisionPanel(context, request, user, item),
+      ],
+    );
+  }
+  
+  String _titleText(Request request) {
+    if(request.type == RequestType.borrow) {
+      return 'Borrow request';
+    } else if(request.type == RequestType.extend) {
+      return 'Time extend request';
+    } else {
+      return 'Item transfer request';
+    }
+  }
+
+  Widget _userPanel(BuildContext context, Request request) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          "Requesting user",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 18,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          decoration: BoxDecoration(
+              color: Theme.of(context).primaryColor,
+              borderRadius: const BorderRadius.all(Radius.circular(10))),
+          padding: const EdgeInsets.all(16),
+          child: UserView(userId: request.issuerId),
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+
+  Widget _itemPanel(BuildContext context, Request request) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          "Item of interest",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 18,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          decoration: BoxDecoration(
+              color: Theme.of(context).primaryColor,
+              borderRadius: const BorderRadius.all(Radius.circular(10))),
+          padding: const EdgeInsets.all(16),
+          child: ItemView(itemId: request.itemId),
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+
+  Widget _requestPanel(BuildContext context, Request request, User user,
+      Item? item) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          "Request",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 18,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          decoration: BoxDecoration(
+              color: Theme.of(context).primaryColor,
+              borderRadius: const BorderRadius.all(Radius.circular(10))),
+          padding: const EdgeInsets.all(16),
+          child: RequestPanel(
+            request: request,
+            user: user,
+            item: item,
+          ),
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+
+  Widget _decisionPanel(BuildContext context, Request request, User user,
+      Item item) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          "Decision",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 18,
+          ),
+        ),
+        const SizedBox(height: 8),
+        RequestDecisionPanel(
+          request: request,
+          user: user,
+          item: item,
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+
+}

--- a/frontend/lendme/lib/screens/requests/request_screen.dart
+++ b/frontend/lendme/lib/screens/requests/request_screen.dart
@@ -60,7 +60,7 @@ class RequestScreen extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _userPanel(context, request),
+        _userPanel(context, request, user),
         _itemPanel(context, request),
         _requestPanel(context, request, user, item),
         if(item != null)
@@ -79,7 +79,7 @@ class RequestScreen extends StatelessWidget {
     }
   }
 
-  Widget _userPanel(BuildContext context, Request request) {
+  Widget _userPanel(BuildContext context, Request request, User user) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -96,11 +96,32 @@ class RequestScreen extends StatelessWidget {
               color: Theme.of(context).primaryColor,
               borderRadius: const BorderRadius.all(Radius.circular(10))),
           padding: const EdgeInsets.all(16),
-          child: UserView(userId: request.issuerId),
+          child: _userPanelContent(context, request, user),
         ),
         const SizedBox(height: 16),
       ],
     );
+  }
+
+  Widget _userPanelContent(BuildContext context, Request request, User user) {
+    final requestedBeMe = request.issuerId == user.uid;
+    if(requestedBeMe) {
+      return Row(
+        mainAxisSize: MainAxisSize.max,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          Text(
+            'You',
+            style: TextStyle(
+              fontSize: 40,
+            ),
+          ),
+        ],
+      );
+    }
+    else {
+      return UserView(userId: request.issuerId);
+    }
   }
 
   Widget _itemPanel(BuildContext context, Request request) {

--- a/frontend/lendme/lib/utils/constants.dart
+++ b/frontend/lendme/lib/utils/constants.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-final dateTimeFormat = DateFormat('dd.MM.yyyy kk:mm');
+final dateTimeFormat = DateFormat('dd.MM.yyyy');
 
 // consts for base_tile.dart
 const tileTextColor = Colors.white;


### PR DESCRIPTION
Request screen created .
Able to show borrow, extend and transfer requests.
It must be invoked with request id.
Clicking accept and deny buttons currently does nothing, but actions may be easily implemented inside requests/handlers.dart file, where are placeholder functions created for this purpose.